### PR TITLE
Initial development

### DIFF
--- a/group/main.tf
+++ b/group/main.tf
@@ -24,3 +24,54 @@ resource "aws_identitystore_group" "groups" {
     description = each.value.description
     identity_store_id = var.identity_store.identity_store_ids[0]
 }
+
+# Entitlements (aka Group-PermissionSet-Account mapping)
+
+locals {
+    # Change this map from being keyed by filename to keyed by permission_set.name, which is more useful here.
+    permission_set_map_by_name = {
+        for permission_set in var.permission_sets :
+            permission_set.permission_set.name => permission_set
+    }
+
+    # A map of account_sets, keyed by name.
+    account_set_map = {
+        for account_set in var.args.account_sets :
+            account_set.name => toset(account_set.accounts)
+    }
+
+    # Build a list of entitlements.
+    entitlement_list = flatten([
+        for role in var.args.roles : [
+            for permission_set in try( role.permission_sets, [] ) : [
+                for account_set in try( permission_set.account_sets, [] ) : [
+                    for account_set_accounts in local.account_set_map[account_set] : {
+                        team = var.args.team.name
+                        role = role.name
+                        account = account_set_accounts
+                        permission_set = permission_set.name
+                    }
+                ]
+            ]
+        ]
+    ])
+    # Create a map of entitlements from the list, keyed by "team_role_account" to be unique.
+    entitlement_map = {
+        for entitlement in local.entitlement_list : "${entitlement.team}_${entitlement.role}_${entitlement.permission_set}_${entitlement.account}" => {
+            group = "${entitlement.team}_${entitlement.role}"
+            account = entitlement.account
+            permission_set = entitlement.permission_set
+        }
+    }
+
+}
+
+resource "aws_ssoadmin_account_assignment" "entitlements" {
+    for_each = local.entitlement_map
+    instance_arn = var.identity_store.arns[0]
+    permission_set_arn = local.permission_set_map_by_name[each.value.permission_set].permission_set.arn
+    principal_id = aws_identitystore_group.groups[each.value.group].group_id # ID of the group created in this module and required for this entitlement.
+    principal_type = "GROUP"
+    target_id = var.aws_account_map[each.value.account] # The ID of the AWS account. Lookup the account id from the name in var.aws_account_map
+    target_type = "AWS_ACCOUNT"
+}

--- a/group/main.tf
+++ b/group/main.tf
@@ -1,0 +1,26 @@
+# Groups
+
+locals {
+    # Build a list of entitlements.
+    group_role_list = flatten([
+        for role in var.args.roles : {
+            team = var.args.team.name
+            role = role.name
+            description = try( role.description, null )
+        }  
+    ])
+    # Create a map of groups and desriptions, keyed by group name (i.e. team_role).
+    group_role_map = {
+        for group in local.group_role_list : "${group.team}_${group.role}" => {
+            name = "${group.team}_${group.role}"
+            description = group.description
+        }
+    } 
+}
+
+resource "aws_identitystore_group" "groups" {
+    for_each = local.group_role_map
+    display_name = each.value.name
+    description = each.value.description
+    identity_store_id = var.identity_store.identity_store_ids[0]
+}

--- a/group/outputs.tf
+++ b/group/outputs.tf
@@ -1,3 +1,7 @@
 output "groups" {
     value = aws_identitystore_group.groups
 }
+
+output "entitlements" {
+    value = aws_ssoadmin_account_assignment.entitlements
+}

--- a/group/outputs.tf
+++ b/group/outputs.tf
@@ -1,0 +1,3 @@
+output "groups" {
+    value = aws_identitystore_group.groups
+}

--- a/group/variables.tf
+++ b/group/variables.tf
@@ -7,3 +7,13 @@ variable "identity_store" {
   description = "AWS Identity Centre configuration."
   type = any
 }
+
+variable "permission_sets" {
+  description = "A map of outputs (resources) from the permission_set module."
+  type = map(any)
+}
+
+variable "aws_account_map" {
+  description = "A map of organisation accounts, keyed by name."
+  type = map(string)
+}

--- a/group/variables.tf
+++ b/group/variables.tf
@@ -1,0 +1,9 @@
+variable "args" {
+  description = "A map of arguments to apply to IDC Groups."
+  type = any
+}
+
+variable "identity_store" {
+  description = "AWS Identity Centre configuration."
+  type = any
+}

--- a/permission-set/main.tf
+++ b/permission-set/main.tf
@@ -1,0 +1,20 @@
+# Permission Set
+
+resource "aws_ssoadmin_permission_set" "permission_set" {
+  instance_arn = var.identity_store.arns[0]
+  name = var.args.name
+  description = var.args.description
+  relay_state = try( var.args.relay_state, null )
+  session_duration = try( var.args.relay_state, "PT1H" )
+  tags = var.tags
+}
+
+## Attached Inline Policy
+
+resource "aws_ssoadmin_permission_set_inline_policy" "inline_policy" {
+  count = can(var.args.inline_policy) ? 1 : 0
+  instance_arn = var.identity_store.arns[0]
+  permission_set_arn = aws_ssoadmin_permission_set.permission_set.arn
+  inline_policy = jsonencode(var.args.inline_policy)
+}
+

--- a/permission-set/main.tf
+++ b/permission-set/main.tf
@@ -18,3 +18,25 @@ resource "aws_ssoadmin_permission_set_inline_policy" "inline_policy" {
   inline_policy = jsonencode(var.args.inline_policy)
 }
 
+## Attached AWS-managed Policies
+
+locals {
+    aws_managed_policies_map_by_name = {
+        for aws_managed_policy in try( var.args.aws_managed_policies, [] ) : aws_managed_policy.name => {
+            name = aws_managed_policy.name
+        }
+    }
+}
+
+data "aws_iam_policy" "aws_managed_policies" {
+    for_each = local.aws_managed_policies_map_by_name
+    name = each.value.name
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "aws_managed_policies" {
+    for_each = local.aws_managed_policies_map_by_name
+    instance_arn = var.identity_store.arns[0]
+    permission_set_arn = aws_ssoadmin_permission_set.permission_set.arn
+    managed_policy_arn = data.aws_iam_policy.aws_managed_policies[each.value.name].arn
+}
+

--- a/permission-set/outputs.tf
+++ b/permission-set/outputs.tf
@@ -14,3 +14,6 @@ output "aws_managed_policy_attachment" {
     value = aws_ssoadmin_managed_policy_attachment.aws_managed_policies
 }
 
+output "customer_managed_policy_attachment" {
+    value = aws_ssoadmin_customer_managed_policy_attachment.external_customer_managed_policies
+}

--- a/permission-set/outputs.tf
+++ b/permission-set/outputs.tf
@@ -1,0 +1,16 @@
+output "permission_set" {
+    value = aws_ssoadmin_permission_set.permission_set
+}
+
+output "inline_policy" {
+    value = aws_ssoadmin_permission_set_inline_policy.inline_policy
+}
+
+output "aws_managed_policy" {
+    value = data.aws_iam_policy.aws_managed_policies
+}
+
+output "aws_managed_policy_attachment" {
+    value = aws_ssoadmin_managed_policy_attachment.aws_managed_policies
+}
+

--- a/permission-set/variables.tf
+++ b/permission-set/variables.tf
@@ -1,0 +1,16 @@
+variable "args" {
+  description = "A map of arguments to apply to IAM."
+  type = any
+}
+
+variable "identity_store" {
+  description = "AWS Identity Centre configuration."
+  type = any
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the resources."
+  type = map(any)
+  default = {}
+}
+


### PR DESCRIPTION
Creates initial Identity Centre Terraform modules for:
- Groups
- Permission Sets
- Permission Set Policies. 3 types:
  - In-line
  - AWS-managed
  - Customer-managed