### PR TITLE
Add support for AWS Organisation OUs

### DIFF
--- a/group/main.tf
+++ b/group/main.tf
@@ -36,7 +36,7 @@ locals {
 
     # A map of account_sets, keyed by name.
     account_set_map = {
-        for account_set in var.args.account_sets :
+        for account_set in try( var.args.account_sets, [] ) :
             account_set.name => toset(account_set.accounts)
     }
 

--- a/group/main.tf
+++ b/group/main.tf
@@ -43,7 +43,7 @@ locals {
     # Build a list of entitlements.
     entitlement_list = flatten([
         for role in var.args.roles : [
-            for permission_set in try( role.permission_sets, [] ) : [
+            for permission_set in try( role.permission_sets, [] ) : concat([
                 for account_set in try( permission_set.account_sets, [] ) : [
                     for account_set_accounts in local.account_set_map[account_set] : {
                         team = var.args.team.name
@@ -52,7 +52,16 @@ locals {
                         permission_set = permission_set.name
                     }
                 ]
-            ]
+            ],[
+                for ou in try( permission_set.ous, [] ) : [
+                    for ou_account in var.org_ou_account_map.descendant_accounts[ou].active : {
+                        team = var.args.team.name
+                        role = role.name
+                        account = ou_account
+                        permission_set = permission_set.name
+                    }
+                ]
+            ])
         ]
     ])
     # Create a map of entitlements from the list, keyed by "team_role_account" to be unique.

--- a/group/variables.tf
+++ b/group/variables.tf
@@ -17,3 +17,9 @@ variable "aws_account_map" {
   description = "A map of organisation accounts, keyed by name."
   type = map(string)
 }
+
+variable "org_ou_account_map" {
+  description = "A map of organisation OUs and AWS accounts."
+  type = map(any)
+  default = {}
+}

--- a/org/README.md
+++ b/org/README.md
@@ -1,0 +1,104 @@
+# Organisation Data module
+This module reads the organisation OU structure and accounts, and produces a map to be used in the `group` module.
+
+For example, an org OU structure like this...
+```
+Root
+┣━ account-a
+┣━ account-b
+┣━ account-c (suspended)
+┣━ account-d (suspended)
+┣━ OU-1
+┃  ┣━ account-e
+┃  ┣━ account-f
+┃  ┗━ OU-2
+┃     ┣━ account-g
+┃     ┗━ account-h
+┗━ OU-3
+   ┣━ account-i
+   ┗━ account-j
+```
+...would result in the following output. Note that `OU-2` is a child of `OU-1` in this example, so the `child_accounts` and `descendant_accounts` reasuts differ for `OU-1`  (and for `Root`) which has a deeper child structure.  
+
+The module outputs a single object `org_ou_account_map` which contains 'child' and 'descendant' values:
+```JSON
+{
+    "org_ou_account_map": {
+        "child_accounts": {
+            "Root": {
+                "active": [
+                    "account-a",
+                    "account-b"
+                ],
+                "inactive": [
+                    "account-c",
+                    "account-d"
+                ]
+            },
+            "OU-1": {
+                "active": [
+                    "account-e",
+                    "account-f"
+                ],
+                "inactive": []
+            },
+            "OU-2": {
+                "active": [
+                    "account-g",
+                    "account-h"
+                ],
+                "inactive": []
+            },
+            "OU-3": {
+                "active": [
+                    "account-i",
+                    "account-j"
+                ],
+                "inactive": []
+            }
+
+        },
+        "descendant_accounts": {
+            "OU-1": {
+                "active": [
+                    "account-e",
+                    "account-f",
+                    "account-g",
+                    "account-h"
+                ],
+                "inactive": []
+            },
+            "OU-2": {
+                "active": [
+                    "account-g",
+                    "account-h"
+                ],
+                "inactive": []
+            },
+            "OU-3": {
+                "active": [
+                    "account-i",
+                    "account-j"
+                ],
+                "inactive": []
+            },
+            "Root": {
+                "active": [
+                    "account-a",
+                    "account-b",
+                    "account-e",
+                    "account-f",
+                    "account-g",
+                    "account-h",
+                    "account-i",
+                    "account-j"
+                ],
+                "inactive": [
+                    "account-c",
+                    "account-d"
+                ]
+            }
+        }
+    }
+}
+```

--- a/org/main.tf
+++ b/org/main.tf
@@ -16,3 +16,10 @@ data "aws_organizations_organizational_unit_descendant_accounts" "accounts" {
   parent_id = each.value
 }
 
+locals {
+  # Map of organisation OUs keyed by name.
+  org_ou_map = merge(
+    { "${data.aws_organizations_organization.org.roots[0].name}" = data.aws_organizations_organization.org.roots[0].id },
+    { for ou in data.aws_organizations_organizational_unit_descendant_organizational_units.ous.children : "${ou.name}" => ou.id }
+  )
+}

--- a/org/main.tf
+++ b/org/main.tf
@@ -1,0 +1,18 @@
+# Organisation data
+
+data "aws_organizations_organization" "org" {}
+
+data "aws_organizations_organizational_unit_descendant_organizational_units" "ous" {
+  parent_id = data.aws_organizations_organization.org.roots[0].id
+}
+
+data "aws_organizations_organizational_unit_child_accounts" "accounts" {
+  for_each = local.org_ou_map
+  parent_id = each.value
+}
+
+data "aws_organizations_organizational_unit_descendant_accounts" "accounts" {
+  for_each = local.org_ou_map
+  parent_id = each.value
+}
+

--- a/org/main.tf
+++ b/org/main.tf
@@ -23,3 +23,39 @@ locals {
     { for ou in data.aws_organizations_organizational_unit_descendant_organizational_units.ous.children : "${ou.name}" => ou.id }
   )
 }
+
+# Build organisation OU Account map
+
+locals {
+  # Map of all accounts directly in the OU. This only contains immediate child accounts, not all children from descendent OUs.
+  child_account_map = {
+    for ou in keys(local.org_ou_map) : "${ou}" => merge (
+      { "active" = [
+        for account in data.aws_organizations_organizational_unit_child_accounts.accounts[ou].accounts :
+          account.name if account.status == "ACTIVE"
+      ]},
+      { "inactive" = [
+        for account in data.aws_organizations_organizational_unit_child_accounts.accounts[ou].accounts :
+          account.name if account.status != "ACTIVE"
+      ]}
+    )
+  }
+  # Map of all accounts in the OU. This contains all accounts from the OU and all descendant / child OUs.
+  descendant_account_map = {
+    for ou in keys(local.org_ou_map) : "${ou}" => merge (
+      { "active" = [
+        for account in data.aws_organizations_organizational_unit_descendant_accounts.accounts[ou].accounts :
+          account.name if account.status == "ACTIVE"
+      ]},
+      { "inactive" = [
+        for account in data.aws_organizations_organizational_unit_descendant_accounts.accounts[ou].accounts :
+          account.name if account.status != "ACTIVE"
+      ]}
+    )
+  }
+  # Combined map of the two above.
+  org_ou_account_map = merge(
+    { "child_accounts" = local.child_account_map },
+    { "descendant_accounts" = local.descendant_account_map },
+  )
+}

--- a/org/outputs.tf
+++ b/org/outputs.tf
@@ -1,0 +1,7 @@
+output "org_ou_map" {
+    value = local.org_ou_map
+}
+
+output "org_ou_account_map" {
+    value = local.org_ou_account_map
+}


### PR DESCRIPTION
Makes the following changes:
- Adds an `org` module which reads organisation OUs and accounts, and creates a map which is then used in the `group` module.
- Updates the `group` module to use OUs:
  - Adds the `org_ou_account_map` variable, which is the map from the `org` module.
  - Adds `permission_set.ous` to the entitlement list (concatenate with `permission_set.account_sets`)
  - Adds a `try` when building `account_set_map` since this might be undefined now.