### PR TITLE
Fix session_duration variable in permission_set resource.

### DIFF
--- a/permission-set/main.tf
+++ b/permission-set/main.tf
@@ -5,7 +5,7 @@ resource "aws_ssoadmin_permission_set" "permission_set" {
   name = var.args.name
   description = var.args.description
   relay_state = try( var.args.relay_state, null )
-  session_duration = try( var.args.relay_state, "PT1H" )
+  session_duration = try( var.args.session_duration, "PT1H" )
   tags = var.tags
 }
 


### PR DESCRIPTION
Makes the following fix:
- corrects the variable used in the `session_duration` argument in the `aws_ssoadmin_permission_set` resource (it was using the `relay_state` var in error).
