### PR TITLE
Add IDC Application support

### DIFF
--- a/application/main.tf
+++ b/application/main.tf
@@ -1,0 +1,27 @@
+# Applications
+
+resource "aws_ssoadmin_application" "sso_application" {
+  name = var.args.name
+  instance_arn = try ( var.args.instance_arn, var.identity_store.arns[0] )
+  application_provider_arn = var.args.application_provider_arn
+  client_token = try ( var.args.client_token, null )
+  description = try ( var.args.description, null )
+  status = try ( var.args.status, null )
+
+  dynamic "portal_options" {
+    for_each = try ( var.args.portal_options, [] )
+    content {
+      visibility = try ( portal_options.value.visibility, null )
+      dynamic "sign_in_options" {
+        for_each = try ( portal_options.value.sign_in_options, [] )
+        content {
+          application_url = try ( sign_in_options.value.application_url, null )
+          origin = sign_in_options.value.origin
+        }
+      }
+    }
+  }
+
+  tags = try ( var.args.tags, null )
+
+}

--- a/application/outputs.tf
+++ b/application/outputs.tf
@@ -1,0 +1,3 @@
+output "sso_application" {
+    value = aws_ssoadmin_application.sso_application
+}

--- a/application/variables.tf
+++ b/application/variables.tf
@@ -1,0 +1,9 @@
+variable "args" {
+  description = "A map of Identity Centre applications."
+  type = any
+}
+
+variable "identity_store" {
+  description = "AWS Identity Centre configuration."
+  type = any
+}

--- a/group/main.tf
+++ b/group/main.tf
@@ -86,3 +86,30 @@ resource "aws_ssoadmin_account_assignment" "entitlements" {
     target_id = var.aws_account_map[each.value.account] # The ID of the AWS account. Lookup the account id from the name in var.aws_account_map
     target_type = "AWS_ACCOUNT"
 }
+
+## Application Entitlements (aka Group-Application mapping)
+
+locals {
+    # A map of applications, keyed by name.
+    application_map_by_name = {
+        for application in var.applications : "${application.sso_application.name}" => application.sso_application
+    }
+    # Build a list of applications.
+    application_list = flatten([
+        for role in var.args.roles : [
+            for application in try( role.applications, [] ) : {
+                team = var.args.team.name
+                role = role.name
+                application_name = application
+            }
+        ]
+    ])
+    # Create a map of applications from the list, keyed by "team_role_application" to be unique.
+    application_map = {
+        for application in local.application_list : "${application.team}_${application.role}_${application.application_name}" => {
+            group = "${application.team}_${application.role}"
+            application_name = application.application_name
+            application_arn = local.application_map_by_name[application.application_name].application_arn
+        }
+    }
+}

--- a/group/main.tf
+++ b/group/main.tf
@@ -25,7 +25,9 @@ resource "aws_identitystore_group" "groups" {
     identity_store_id = var.identity_store.identity_store_ids[0]
 }
 
-# Entitlements (aka Group-PermissionSet-Account mapping)
+# Entitlements
+
+## Permission-set Entitlements (aka Group-PermissionSet-Account mapping)
 
 locals {
     # Change this map from being keyed by filename to keyed by permission_set.name, which is more useful here.

--- a/group/main.tf
+++ b/group/main.tf
@@ -113,3 +113,10 @@ locals {
         }
     }
 }
+
+resource "aws_ssoadmin_application_assignment" "application_assignments" {
+  for_each = local.application_map
+  principal_id = aws_identitystore_group.groups[each.value.group].group_id
+  principal_type  = "GROUP"
+  application_arn = each.value.application_arn
+}

--- a/group/variables.tf
+++ b/group/variables.tf
@@ -13,6 +13,12 @@ variable "permission_sets" {
   type = map(any)
 }
 
+variable "applications" {
+  description = "A map of application resources from the application module."
+  type = map(any)
+  default = {}
+}
+
 variable "aws_account_map" {
   description = "A map of organisation accounts, keyed by name."
   type = map(string)


### PR DESCRIPTION
Makes the following changes:
- Adds an **application** module to create `aws_ssoadmin_application` resources.
  - This outputs the application resource details.
- Adds `aws_ssoadmin_application_assignment` to the **groups** module (and required variables) to allow the applications to be assigned to groups.